### PR TITLE
Add Setting::value reader

### DIFF
--- a/src/payload.rs
+++ b/src/payload.rs
@@ -334,6 +334,11 @@ impl Setting {
     }
 
     #[inline]
+    pub fn value(&self) -> u32 {
+        self.value
+    }
+
+    #[inline]
     fn to_bytes(settings: &[Setting]) -> &[u8] {
         unsafe {
             slice::from_raw_parts(


### PR DESCRIPTION
It didn't look like there was a way to get access to the setting value.
